### PR TITLE
Option to not register hooks and bail if hooks fail

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -48,6 +48,7 @@ async function createHook() {
 
   const checksum = Utils.checksumAPI(fullUrl, SHARED_SECRET, CHECKSUM_ALGORITHM);
   const urlWithChecksum = `${fullUrl}&checksum=${checksum}`;
+  let success;
 
   logger.info(`Final URL with checksum: ${urlWithChecksum}`);
 
@@ -57,11 +58,18 @@ async function createHook() {
       if (hookIdMatch) {
         storedHookId = hookIdMatch[1];
         logger.info(`Hook created with ID: ${storedHookId}`);
+        success = true;
       } else {
         logger.error('Failed to parse hook ID');
+        success = false;
       }
     } else {
       logger.error('Failed to create hook', error);
+      success = false;
+    }
+    if (!success) {
+      logger.error("No webhooks, exiting!");
+      process.exit(1);
     }
   });
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,7 @@ const SHARED_SECRET = process.env.SHARED_SECRET;
 const CHECKSUM_ALGORITHM = 'sha1';
 const BASIC_URL = process.env.BASIC_URL;
 const API_PATH = process.env.API_PATH;
+const REGISTER_HOOKS = process.env.REGISTER_HOOKS || false;
 const HOOKS_CREATE = process.env.HOOKS_CREATE || 'hooks/create';
 const HOOKS_DESTROY = process.env.HOOKS_DESTROY || 'hooks/destroy';
 const CALLBACK_PATH = process.env.CALLBACK_PATH;
@@ -230,17 +231,18 @@ app.post('/feedback/submit', async (req, res) => {
 
 app.listen(port, async () => {
   logger.info(`Server listening on port ${port}`);
-  await createHook();
+  if (REGISTER_HOOKS) {
+    await createHook();
+  }
 });
 
-process.on('SIGINT', async () => {
+const destroyBeforeExit = async () => {
   logger.info('Shutting down server...');
-  await destroyHook();
+  if (REGISTER_HOOK) {
+    await destroyHook();
+  }
   process.exit(0);
-});
+};
 
-process.on('SIGTERM', async () => {
-  logger.info('Shutting down server...');
-  await destroyHook();
-  process.exit(0);
-});
+process.on('SIGINT', destroyBeforeExit);
+process.on('SIGTERM', destroyBeforeExit);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,4 @@ services:
       - LOG_STDOUT=true
       - PORT=3009
       - REDIS_HOST=localhost
+      - REGISTER_HOOKS=false


### PR DESCRIPTION

* Option to not register hooks automatically. This is useful for using bbb-webhooks with permanent hooks
* If using hook registration and it fails the server will just exit(1). This is useful for debugging and or deployments where custom-feedback might be up before webhooks is available.