### PR TITLE
fix: client not redirected when feedback is directly skipped

### DIFF
--- a/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
+++ b/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import Styled from './styles';
 import { defineMessages, injectIntl } from 'react-intl';
 
@@ -22,7 +22,7 @@ const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout }) => {
     }, redirectTimeout || 10000);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [getRedirectTimeout, getRedirectUrl]);
 
   return (
     <Styled.Container>


### PR DESCRIPTION
Fixes the case where the client was not redirected after directly skipping the whole feedback by adding a specific case for handling those cases, where the redireect url should be returned and the feedback object should not be manipulated as the values can be undefined leading to errors.