### PR TITLE
feat: add support for 'ask_for_feedback_on_logout' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ At the end of the feedback process, the HTTP server receives the feedback data a
 
     docker-compose up
 
-Changes the docker-compose.yml to fit your use caser:
+Changes the docker-compose.yml to fit your use case. **Note:** Ensure there are no spaces between the variable name and the equals sign (e.g., `VAR=value`, not `VAR = value`).
 
     FEEDBACK_URL (optional)
       Where to submit the feedback object. With no URL results will be exclusivelly logged
 
-   SHARED_SECRET
-     Your server's shared secret used to register web hooks
+    SHARED_SECRET
+      Your server's shared secret used to register web hooks
 
     BASIC_URL
       Domain of your server without the /bigbluebutton/
@@ -56,7 +56,7 @@ Changes the docker-compose.yml to fit your use caser:
 After spinning up the back-end server you'll need to drop this nginx file on your server:
 
 ```
-/usr/share/local/bigbluebutton/feedback.nginx
+/usr/share/bigbluebutton/feedback.nginx
 
 location /feedback {
         proxy_pass http://localhost:3009/feedback;

--- a/backend/server.js
+++ b/backend/server.js
@@ -100,7 +100,7 @@ app.use('/feedback', async (req, res, next) => {
     
     if (userData.ask_for_feedback === 'false') {
       const finalRedirectUrl = userData.redirect_url || sessionData.redirect_url || '';
-      const redirectTimeout = sessionData.redirect_timeout || REDIRECT_TIMEOUT || '10000';
+      const redirectTimeout = sessionData.redirect_timeout || REDIRECT_TIMEOUT;
 
       const params = new URLSearchParams({
         meetingId: req.query.meetingId,
@@ -262,9 +262,9 @@ app.post('/feedback/submit', async (req, res) => {
     const logLevel = logger.level;
 
     if (cleanFeedback.rating) {
-        console.log(`${new Date().toISOString()} custom-feedback [${logLevel}] : CUSTOM FEEDBACK LOG: ${JSON.stringify(cleanFeedback)}`);
+      console.log(`${new Date().toISOString()} custom-feedback [${logLevel}] : CUSTOM FEEDBACK LOG: ${JSON.stringify(cleanFeedback)}`);
     } else {
-        return logger.info(`Not logging feedback without rating`);
+      return logger.info(`Not logging feedback without rating`);
     }
 
     await redisClient.set(feedbackKey, JSON.stringify(completeFeedback), { EX: 3600 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ import request from 'request';
 import path from 'path';
 import Utils from './utils.js';
 import pino from 'pino';
+import { URLSearchParams } from 'url';
 
 const app = express();
 const port = process.env.PORT || 3009;
@@ -90,7 +91,31 @@ async function destroyHook() {
   }
 }
 
-app.use('/feedback', (req, res, next) => {
+app.use('/feedback', async (req, res, next) => {
+  const { userId, meetingId } = req.query;
+
+  if (userId && meetingId && !req.query.skipped) {
+    const userData = await redisClient.hGetAll(`user:${userId}`);
+    const sessionData = await redisClient.hGetAll(`session:${meetingId}`);
+
+    if (userData.ask_for_feedback === 'false') {
+      const finalRedirectUrl = userData.redirect_url || sessionData.redirect_url || '';
+      const params = new URLSearchParams({
+        meetingId: req.query.meetingId,
+        userId: req.query.userId,
+        skipped: 'true',
+        redirectUrl: finalRedirectUrl,
+      });
+
+      if (req.query.locale) {
+        params.set('locale', req.query.locale);
+      }
+
+      logger.info(`Feedback skipped for user ${userId}, redirecting to confirmation screen.`);
+      return res.redirect(`/feedback?${params.toString()}`);
+    }
+  }
+
   const userLocale = usersLocales[req.query.userId];
   if (userLocale && !req.query.locale) {
     req.query.locale = userLocale;
@@ -101,6 +126,7 @@ app.use('/feedback', (req, res, next) => {
   }
   next();
 }, express.static(path.resolve('./public')));
+
 
 app.post('/feedback/webhook', async (req, res) => {
   try {
@@ -138,6 +164,10 @@ app.post('/feedback/webhook', async (req, res) => {
         } else if (eventType === 'user-joined') {
           const user = evt.data.attributes.user;
           const userRedirectUrl = user.userdata?.['bbb_feedback_redirect_url'];
+          const askForFeedback = user.userdata?.['bbb_ask_for_feedback_on_logout'];
+          
+          logger.info("USERDATA received for user " + user['internal-user-id'], user.userdata);
+
           const userData = {
             name: user.name,
             id: user['internal-user-id'],
@@ -145,6 +175,11 @@ app.post('/feedback/webhook', async (req, res) => {
           };
 
           if (userRedirectUrl) userData.redirect_url = userRedirectUrl;
+
+          if (askForFeedback !== undefined) {
+            userData.ask_for_feedback = askForFeedback;
+            logger.info(`ask_for_feedback for user ${user['internal-user-id']} is ${askForFeedback}`);
+          }
 
           const overrideDefaultLocale = user.userdata?.['bbb_override_default_locale'];
           if (overrideDefaultLocale) {
@@ -220,9 +255,9 @@ app.post('/feedback/submit', async (req, res) => {
     const logLevel = logger.level;
 
     if (cleanFeedback.rating) {
-      console.log(`${new Date().toISOString()} custom-feedback [${logLevel}] : CUSTOM FEEDBACK LOG: ${JSON.stringify(cleanFeedback)}`);
+        console.log(`${new Date().toISOString()} custom-feedback [${logLevel}] : CUSTOM FEEDBACK LOG: ${JSON.stringify(cleanFeedback)}`);
     } else {
-      return logger.info(`Not logging feedback without rating`);
+        return logger.info(`Not logging feedback without rating`);
     }
 
     await redisClient.set(feedbackKey, JSON.stringify(completeFeedback), { EX: 3600 });
@@ -257,7 +292,7 @@ app.listen(port, async () => {
 
 const destroyBeforeExit = async () => {
   logger.info('Shutting down server...');
-  if (REGISTER_HOOK) {
+  if (REGISTER_HOOKS) {
     await destroyHook();
   }
   process.exit(0);

--- a/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
+++ b/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
@@ -15,17 +15,15 @@ const messages = defineMessages({
 
 const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout, endReason, isSkipped }) => {
   useEffect(() => {
-    const redirectTimeout = getRedirectTimeout ? getRedirectTimeout() : 10000;
+    const redirectTimeout = getRedirectTimeout ? getRedirectTimeout() : null;
     const timer = setTimeout(() => {
       const redirectUrl = getRedirectUrl ? getRedirectUrl() : null;
       if (redirectUrl) {
         window.location.href = redirectUrl;
       } else {
-        if (!isSkipped) {
-            window.close();
-        }
+        window.close();
       }
-    }, redirectTimeout);
+    }, redirectTimeout || 10000);
 
     return () => clearTimeout(timer);
   }, [getRedirectTimeout, getRedirectUrl, isSkipped]);

--- a/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
+++ b/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
@@ -6,27 +6,34 @@ const messages = defineMessages({
   confirmationMessage: {
     id: 'app.customFeedback.confirmation.message',
     description: 'Thank you for your feedback! The window will close shortly.'
+  },
+  skippedMessage: {
+    id: 'app.customFeedback.skipped.message',
+    description: 'Your session has ended. You may now close this window.'
   }
 });
 
-const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout }) => {
+const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout, isSkipped }) => {
   useEffect(() => {
     const redirectTimeout = getRedirectTimeout ? getRedirectTimeout() : null;
     const timer = setTimeout(() => {
       const redirectUrl = getRedirectUrl ? getRedirectUrl() : null;
       if (redirectUrl) {
         window.location.href = redirectUrl;
-      } else {
+      } else if (!isSkipped) {
         window.close();
       }
     }, redirectTimeout || 10000);
 
     return () => clearTimeout(timer);
-  }, [getRedirectTimeout, getRedirectUrl]);
+  }, [getRedirectTimeout, getRedirectUrl, isSkipped]);
+
+  const message = isSkipped ? messages.skippedMessage : messages.confirmationMessage;
+  const showDots = !isSkipped;
 
   return (
     <>
-      <Styled.Description>{intl.formatMessage(messages.confirmationMessage)}<Styled.Dots/></Styled.Description>
+      <Styled.Description>{intl.formatMessage(message)}{showDots && <Styled.Dots/>}</Styled.Description>
     </>
   );
 };

--- a/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
+++ b/frontend/src/components/ConfirmatioStep/ConfirmationStep.js
@@ -8,32 +8,34 @@ const messages = defineMessages({
     description: 'Thank you for your feedback! The window will close shortly.'
   },
   skippedMessage: {
-    id: 'app.customFeedback.skipped.message',
-    description: 'Your session has ended. You may now close this window.'
+    id: 'app.customFeedback.windowWillClose',
+    description: 'The window will close shortly.'
   }
 });
 
-const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout, isSkipped }) => {
+const ConfirmationStep = ({ intl, getRedirectUrl, getRedirectTimeout, endReason, isSkipped }) => {
   useEffect(() => {
-    const redirectTimeout = getRedirectTimeout ? getRedirectTimeout() : null;
+    const redirectTimeout = getRedirectTimeout ? getRedirectTimeout() : 10000;
     const timer = setTimeout(() => {
       const redirectUrl = getRedirectUrl ? getRedirectUrl() : null;
       if (redirectUrl) {
         window.location.href = redirectUrl;
-      } else if (!isSkipped) {
-        window.close();
+      } else {
+        if (!isSkipped) {
+            window.close();
+        }
       }
-    }, redirectTimeout || 10000);
+    }, redirectTimeout);
 
     return () => clearTimeout(timer);
   }, [getRedirectTimeout, getRedirectUrl, isSkipped]);
 
   const message = isSkipped ? messages.skippedMessage : messages.confirmationMessage;
-  const showDots = !isSkipped;
 
   return (
     <>
-      <Styled.Description>{intl.formatMessage(message)}{showDots && <Styled.Dots/>}</Styled.Description>
+      {endReason && <Styled.EndedTitle>{endReason}</Styled.EndedTitle>}
+      <Styled.Description>{intl.formatMessage(message)}<Styled.Dots/></Styled.Description>
     </>
   );
 };

--- a/frontend/src/components/ConfirmatioStep/styles.js
+++ b/frontend/src/components/ConfirmatioStep/styles.js
@@ -1,5 +1,14 @@
 import styled, { keyframes } from 'styled-components';
 
+const EndedTitle = styled.span`
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  display: block;
+  margin-bottom: 16px;
+`;
+
 const Description = styled.div`
   font-size: 16px;
   font-style: normal;
@@ -25,6 +34,7 @@ const Dots = styled.span`
 `;
 
 const styles = {
+  EndedTitle,
   Description,
   dotAnimation,
   Dots,

--- a/frontend/src/components/FeedbackFlow/FeedbackFlow.js
+++ b/frontend/src/components/FeedbackFlow/FeedbackFlow.js
@@ -19,6 +19,8 @@ const FeedbackFlow = ({ intl }) => {
   const [currentStep, setCurrentStep] = useState('rating');
   const [isValidSession, setIsValidSession] = useState(true);
   const [isSkipped, setIsSkipped] = useState(false);
+  const [endReason, setEndReason] = useState(null);
+
   const feedback = useRef({
     session: {},
     device: getDeviceInfo(),
@@ -40,12 +42,21 @@ const FeedbackFlow = ({ intl }) => {
     const userId = params.get('userId');
     const skipped = params.get('skipped') === 'true';
     const finalRedirectUrl = params.get('redirectUrl');
+    const redirectTimeout = params.get('redirectTimeout');
+    const reason = params.get('reason');
+
+    if (reason) {
+      setEndReason(reason);
+    }
 
     if (skipped) {
       setIsSkipped(true);
       setCurrentStep('confirmation');
       if (finalRedirectUrl) {
         sessionStorage.setItem('redirectUrl', finalRedirectUrl);
+      }
+      if (redirectTimeout) {
+        sessionStorage.setItem('redirectTimeout', redirectTimeout);
       }
       return;
     }
@@ -123,20 +134,22 @@ const FeedbackFlow = ({ intl }) => {
         return <EmailStep key="email" onNext={handleNext} stepData={feedbackData.email} />;
       case 'confirmation':
       default:
-        return <ConfirmationStep isSkipped={isSkipped} getRedirectUrl={getRedirectUrl} getRedirectTimeout={getRedirectTimeout} />;
+        return <ConfirmationStep isSkipped={isSkipped} endReason={endReason} getRedirectUrl={getRedirectUrl} getRedirectTimeout={getRedirectTimeout} />;
     }
   };
 
   const isStepValid = feedbackData && currentStep && feedbackData[currentStep];
-  const hasTitle = isStepValid && Object.keys(feedbackData[currentStep]).includes("titleLabel");
+  const hasTitle = isStepValid && Object.keys(feedbackData[currentStep]).includes("titleLabel"); 
 
   return (
     <Styled.Container>
       <Styled.Box>
-        <Styled.TitleWrapper>
-          <Styled.Title>{intl.formatMessage(messages.feedbackTitle)}</Styled.Title>
-          {isStepValid && !isSkipped && <Styled.Progress>{feedbackData[currentStep].progress}</Styled.Progress>}
-        </Styled.TitleWrapper> 
+        {!isSkipped && (
+          <Styled.TitleWrapper>
+            <Styled.Title>{intl.formatMessage(messages.feedbackTitle)}</Styled.Title>
+            {isStepValid && <Styled.Progress>{feedbackData[currentStep].progress}</Styled.Progress>}
+          </Styled.TitleWrapper>
+        )}
         {hasTitle && !isSkipped && (
           <Styled.StepTitle>{intl.formatMessage(feedbackData[currentStep].titleLabel)}</Styled.StepTitle>
         )}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,6 +1,6 @@
 { 
   "app.customFeedback.confirmation.message": "Thank you for your feedback! The window will close shortly",
-  "app.customFeedback.skipped.message": "Your session has ended. You may now close this window.",
+  "app.customFeedback.windowWillClose": "The window will close shortly",
   "app.customFeedback.feedbackTitle": "End-of-Session Feedback",
   "app.customFeedback.defaultButtons.next": "Continue",
   "app.customFeedback.defaultButtons.nextDesc": "Proceed to the next step of the feedback",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 { 
   "app.customFeedback.confirmation.message": "Thank you for your feedback! The window will close shortly",
+  "app.customFeedback.skipped.message": "Your session has ended. You may now close this window.",
   "app.customFeedback.feedbackTitle": "End-of-Session Feedback",
   "app.customFeedback.defaultButtons.next": "Continue",
   "app.customFeedback.defaultButtons.nextDesc": "Proceed to the next step of the feedback",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1,5 +1,6 @@
-{ 
+{
   "app.customFeedback.confirmation.message": "¡Gracias por tus comentarios! La ventana se cerrará en breve.",
+  "app.customFeedback.skipped.message": "Tu sesión ha finalizado. Ya puedes cerrar esta ventana.",
   "app.customFeedback.feedbackTitle": "Comentarios al Final de la Sesión",
   "app.customFeedback.defaultButtons.next": "Continuar",
   "app.customFeedback.defaultButtons.nextDesc": "Avanzar al siguiente paso del feedback",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1,6 +1,6 @@
 {
   "app.customFeedback.confirmation.message": "¡Gracias por tus comentarios! La ventana se cerrará en breve.",
-  "app.customFeedback.skipped.message": "Tu sesión ha finalizado. Ya puedes cerrar esta ventana.",
+  "app.customFeedback.windowWillClose": "La ventana se cerrará en breve.",
   "app.customFeedback.feedbackTitle": "Comentarios al Final de la Sesión",
   "app.customFeedback.defaultButtons.next": "Continuar",
   "app.customFeedback.defaultButtons.nextDesc": "Avanzar al siguiente paso del feedback",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1,5 +1,6 @@
 { 
   "app.customFeedback.confirmation.message": "Grazie per il tuo feedback! La finestra si chiuderà a breve",
+  "app.customFeedback.skipped.message": "La tua sessione è terminata. Ora puoi chiudere questa finestra.",
   "app.customFeedback.feedbackTitle": "Feedback di fine sessione",
   "app.customFeedback.defaultButtons.next": "Continua",
   "app.customFeedback.defaultButtons.nextDesc": "Procedi alla fase successiva del feedback",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1,6 +1,6 @@
 { 
   "app.customFeedback.confirmation.message": "Grazie per il tuo feedback! La finestra si chiuderà a breve",
-  "app.customFeedback.skipped.message": "La tua sessione è terminata. Ora puoi chiudere questa finestra.",
+  "app.customFeedback.windowWillClose": "La finestra si chiuderà a breve",
   "app.customFeedback.feedbackTitle": "Feedback di fine sessione",
   "app.customFeedback.defaultButtons.next": "Continua",
   "app.customFeedback.defaultButtons.nextDesc": "Procedi alla fase successiva del feedback",

--- a/frontend/src/locales/pt_BR.json
+++ b/frontend/src/locales/pt_BR.json
@@ -1,5 +1,6 @@
-{ 
+{
   "app.customFeedback.confirmation.message": "Obrigado pelo seu feedback! A janela fechará em breve",
+  "app.customFeedback.skipped.message": "Sua sessão foi encerrada. Você já pode fechar esta janela.",
   "app.customFeedback.feedbackTitle": "Feedback de Final de Sessão",
   "app.customFeedback.defaultButtons.next": "Continuar",
   "app.customFeedback.defaultButtons.nextDesc": "Passar para a próxima etapa do feedback",

--- a/frontend/src/locales/pt_BR.json
+++ b/frontend/src/locales/pt_BR.json
@@ -1,6 +1,6 @@
 {
   "app.customFeedback.confirmation.message": "Obrigado pelo seu feedback! A janela fechará em breve",
-  "app.customFeedback.skipped.message": "Sua sessão foi encerrada. Você já pode fechar esta janela.",
+  "app.customFeedback.windowWillClose": "A janela fechará em breve",
   "app.customFeedback.feedbackTitle": "Feedback de Final de Sessão",
   "app.customFeedback.defaultButtons.next": "Continuar",
   "app.customFeedback.defaultButtons.nextDesc": "Passar para a próxima etapa do feedback",


### PR DESCRIPTION
 ### Feature: Skip feedback based on user parameter

- Added support for the `userdata-bbb_ask_for_feedback_on_logout` parameter.
- If the value is `false`, the user will not see the feedback form.
- Instead, the page will be redirected to the `feedbackredirecturl` or closed.
- The default behavior of showing the feedback remains if the parameter is `true` or not present.

### More
userdata-bbb_ask_for_feedback_on_logout=true
[Screencast from 25-07-2025 15:09:36.webm](https://github.com/user-attachments/assets/751fcc4e-253c-4bca-aa4b-cd169354bbb9)

userdata-bbb_ask_for_feedback_on_logout=false
[Screencast from 25-07-2025 15:10:28.webm](https://github.com/user-attachments/assets/9d85d457-4621-4ca2-8901-79e64f51d19c)
