### PR TITLE
fix: styles adjustments & remove progress indicador on error screen

### DIFF
--- a/frontend/public/index.css
+++ b/frontend/public/index.css
@@ -1,6 +1,12 @@
+body,
+button,
+input,
+textarea {
+  font-family: 'Source Sans Pro', Arial, sans-serif;
+}
+
 body {
   margin: 0;
-  font-family: 'Source Sans Pro', Arial, sans-serif;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/frontend/src/components/FeedbackFlow/FeedbackFlow.js
+++ b/frontend/src/components/FeedbackFlow/FeedbackFlow.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { injectIntl, defineMessages } from 'react-intl';
-import { getDeviceInfo, getURLParams, submitFeedback, handleBeforeUnload, getRedirectUrl, getRedirectTimeout } from '../service';
+import { getDeviceInfo, submitFeedback, handleBeforeUnload, getRedirectUrl, getRedirectTimeout } from '../service';
 import RatingStep from '../RatingStep/RatingStep';
 import ProblemStep from '../ProblemStep/ProblemStep';
 import EmailStep from '../EmailStep/EmailStep';
@@ -138,8 +138,7 @@ const FeedbackFlow = ({ intl }) => {
     }
   };
 
-  const isStepValid = feedbackData && currentStep && feedbackData[currentStep];
-  const hasTitle = isStepValid && Object.keys(feedbackData[currentStep]).includes("titleLabel"); 
+  const isStepValid = feedbackData && currentStep && feedbackData[currentStep] && isValidSession;
 
   return (
     <Styled.Container>
@@ -149,9 +148,6 @@ const FeedbackFlow = ({ intl }) => {
             <Styled.Title>{intl.formatMessage(messages.feedbackTitle)}</Styled.Title>
             {isStepValid && <Styled.Progress>{feedbackData[currentStep].progress}</Styled.Progress>}
           </Styled.TitleWrapper>
-        )}
-        {hasTitle && !isSkipped && (
-          <Styled.StepTitle>{intl.formatMessage(feedbackData[currentStep].titleLabel)}</Styled.StepTitle>
         )}
         {renderStep()}
       </Styled.Box>

--- a/frontend/src/components/FeedbackFlow/styles.js
+++ b/frontend/src/components/FeedbackFlow/styles.js
@@ -59,20 +59,12 @@ const Progress = styled.div`
   align-content: center;
 `;
 
-const StepTitle = styled.div`
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: normal;
-`;
-
 const styles = {
   Container,
   Box,
   TitleWrapper,
   Title,
   Progress,
-  StepTitle,
 }
 
 export default styles;

--- a/frontend/src/components/ProblemStep/ProblemStep.js
+++ b/frontend/src/components/ProblemStep/ProblemStep.js
@@ -17,6 +17,7 @@ const messages = defineMessages({
 const ProblemStep = ({ onNext, stepData, intl }) => {
   const [selectedOption, setSelectedOption] = useState(null);
   const [textValue, setTextValue] = useState('');
+  const hasTitle = Object.keys(stepData).includes("titleLabel"); 
 
   useEffect(() => {
     setSelectedOption(null);
@@ -50,35 +51,44 @@ const ProblemStep = ({ onNext, stepData, intl }) => {
   };
 
   return (
-    <Styled.OptionsWrapper>
-      {stepData.options.map((option, index) => (
-        <Styled.Option key={index}>
-          {option.type === 'radio' ? (
-            <Styled.ClicableArea>
-              <Styled.RadioButton
-                type="radio"
-                id={option.value}
-                name={`problem-${stepData.titleLabel.id}`}
-                value={option.value}
-                checked={selectedOption ? selectedOption.value === option.value : false}
-                onChange={() => handleOptionChange(option)}
-              />
-              <Styled.Label htmlFor={option.value}>{intl.formatMessage({ id: option.textLabel.id })}</Styled.Label>
-            </Styled.ClicableArea>
-          ) : (
-            <Styled.TextArea
-              value={textValue}
-              onFocus={() => handleOptionChange({value: 'other'})}
-              onClick={() => handleOptionChange({value: 'other'})}
-              onChange={(selectedOption || selectedOption?.value === 'other')
-                ? handleTextChange
-                : () => {}
-              }
-              placeholder={intl.formatMessage(messages.describeProblem)}
-            />
+    <Styled.ProblemWrapper>
+      <Styled.TitleOptionsWrapper>
+        {hasTitle && (
+          <Styled.StepTitle>{intl.formatMessage(stepData.titleLabel)}</Styled.StepTitle>
+        )}
+        <Styled.OptionsWrapper>
+          {stepData.options.map((option, index) =>
+            option.type === 'radio' ? (
+              <Styled.Option key={index}>
+                <Styled.ClicableArea>
+                  <Styled.RadioButton
+                    type="radio"
+                    id={option.value}
+                    name={`problem-${stepData.titleLabel.id}`}
+                    value={option.value}
+                    checked={selectedOption ? selectedOption.value === option.value : false}
+                    onChange={() => handleOptionChange(option)}
+                  />
+                  <Styled.Label htmlFor={option.value}>{intl.formatMessage({ id: option.textLabel.id })}</Styled.Label>
+                </Styled.ClicableArea>
+              </Styled.Option>
+            ) : null
           )}
-        </Styled.Option>
-      ))}
+        </Styled.OptionsWrapper>
+        {stepData.options.find((option) => option.type === 'textArea') && (
+          <Styled.TextArea
+            name="other"
+            value={textValue}
+            onFocus={() => handleOptionChange({value: 'other'})}
+            onClick={() => handleOptionChange({value: 'other'})}
+            onChange={(selectedOption || selectedOption?.value === 'other')
+              ? handleTextChange
+              : () => {}
+            }
+            placeholder={intl.formatMessage(messages.describeProblem)}
+          />
+        )}
+      </Styled.TitleOptionsWrapper>
       <Styled.ButtonContainer>
         <Styled.Button onClick={handleLeave} ghosted="true">
           {intl.formatMessage(messages.skip)}
@@ -87,7 +97,7 @@ const ProblemStep = ({ onNext, stepData, intl }) => {
           {intl.formatMessage(messages.continue)}
         </Styled.Button>
       </Styled.ButtonContainer>
-    </Styled.OptionsWrapper>
+    </Styled.ProblemWrapper>
   );
 };
 

--- a/frontend/src/components/ProblemStep/styles.js
+++ b/frontend/src/components/ProblemStep/styles.js
@@ -1,4 +1,3 @@
-
 import styled from 'styled-components';
 import {
   btnPrimaryBg,
@@ -7,6 +6,18 @@ import {
   colorGray,
   defaultBorderColor,
 } from '../../ui/palette';
+
+const ProblemWrapper = styled.div`
+  display: flex;
+  flex-flow: column;
+  gap: 24px;
+`;
+
+const TitleOptionsWrapper = styled.div`
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+`;
 
 const OptionsWrapper = styled.div`
   display: flex;
@@ -23,13 +34,11 @@ const Option = styled.div`
 const TextArea = styled.textarea`
   width: 100%;
   padding: 16px;
-  margin-top: 16px;
   box-sizing: border-box;
   border: 1px solid ${defaultBorderColor};
   border-radius: 16px;
   resize: none;
   align-items: center;
-  font-family: 'Source Sans Pro', Arial, sans-serif;
   min-height: 56px;
   font-size: 16px;
   font-style: normal;
@@ -76,7 +85,16 @@ const Button = styled.button`
   }
 `;
 
+const StepTitle = styled.div`
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+`;
+
 const styles = {
+  ProblemWrapper,
+  TitleOptionsWrapper,
   OptionsWrapper,
   Option,
   TextArea,
@@ -85,6 +103,7 @@ const styles = {
   RadioButton,
   ButtonContainer,
   Button,
+  StepTitle,
 };
 
 export default styles;


### PR DESCRIPTION
### What does this PR do?
- Updates the spacing between the options and the buttons.
- Removes progress indicator on error screen.

<img width="500" alt="Screenshot from 2025-08-08 16-34-20" src="https://github.com/user-attachments/assets/6621e71e-ddeb-4b33-a4a4-8626459eb0fb" />
<img width="500" alt="Screenshot from 2025-08-08 16-34-28" src="https://github.com/user-attachments/assets/6c0f1143-538c-4a95-813e-5e249f151185" />


### Closes
Closes #22 
Closes #20 

### More
Still pending:
- [ ] Change font to 'Nunito Sans'
  - To be changed with the core