### PR TITLE
fix(backend): handle Redis hash keys with expiration and cleanup

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
 import App from './App';
@@ -15,10 +14,9 @@ const messages = userLocale.startsWith('pt') ? pt_BR :
                  userLocale.startsWith('es') ? es :
                  en;
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
   <IntlProvider locale={userLocale} messages={messages}>
     <App />
-  </IntlProvider>,
-  document.getElementById('root')
+  </IntlProvider>
 );
-


### PR DESCRIPTION
### What does this PR do?
Adds a common `feedback:` prefix to all Redis hash keys, making feedback entries easy to identify in the Redis hash table.
Introduces an auxiliary function to create new Redis hash entries with an expiration time. The default expiration time is 1 hour, configurable via the `REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS` environment variable.
Implements a cleanup routine that retrieves all Redis hash keys containing the `userId` and `sessionId` of logged feedback, and safely removes them from the Redis hash table.

Additionally it also fixes deprecated `ReactDOM.render` in React 18.

### Closes
Closes #28