### PR TITLE
fix(backend): extend default expiration of redis hash keys

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -4,7 +4,7 @@ import crypto from "crypto";
 const activeKeys = [];
 
 const apiPath = process.env.API_PATH || '/bigbluebutton/api/';
-const REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS = process.env.REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS || 3600;
+const REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS = process.env.REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS || 24 * 3600;
 
 /**
  * queryFromUrl - Returns the query string from a URL string while preserving


### PR DESCRIPTION
### Description
Increase the default TTL of redis hash keys to 24h. Some values are populated by webhooks at meeting start, so the key must persist for the entire meeting until the last user submits feedback and one hour was not enough.