### PR TITLE
fix: missing institution fields from feedbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### UNRELEASED
+
+* fix: missing institution fields from feedbacks
+
 ### v1.7.0
 
 * feat: add support for 'ask_for_feedback_on_logout' parameter

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -183,18 +183,20 @@ const hSetWithExpiration = async (redisClient, key, field, expire_seconds=REDIS_
 }
 
 /**
- * redisStaleKeysCleanup - Removes keys from the hash table for that given userId and sessionId.
+ * redisStaleKeysCleanup - Removes keys from the hash table for a given keyId.
  * @param {import("redis").RedisClientType} redisClient - A connected Redis client instance
- * @param {string} userId - the userId present on the stale keys to be removed
- * @param {string} sessionId  - the sessionId on the stale keys to be removed
+ * @param {string} keyId - The keyId to be removed. A keyId is a unique identifier
+ *                         present at the end of keys (e.g. `feedback:<key>:<keyId>`).
  */
-const redisStaleKeysCleanup = async (redisClient, userId, sessionId) => {
+const redisStaleKeysCleanup = async (redisClient, keyId) => {
+  if (!keyId) return;
+
   const { keysToDelete, keysToKeep } = activeKeys.reduce((acc, key) => {
-    // searches for the keys containing userId or sessionId 
+    // searches for the keys containing the keyId
     // Keys have the following format:
-    // - feedback:session:<sessionId>
-    // - feedback:user:<userId>
-    if (key.includes(userId) || key.includes(sessionId)) {
+    // - feedback:session:<keyId>
+    // - feedback:user:<keyId>
+    if (key.includes(keyId)) {
       acc.keysToDelete.push(key);
     } else {
       acc.keysToKeep.push(key);


### PR DESCRIPTION
Institution fields are missing for feedbacks other than the first one
submitted in a session. That is caused by cleaning session info from
Redis earlier than necessary (after the first feedback for a meeting is
submitted).

Only clear Redis info for a session once the session ends via a
meeting-ended webhook event. This fix includes a refactor in the Redis
cleanup util so that user/session entries can be removed separately.