### PR TITLE
fix(frontend): improves error handling for invalid sessions

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,4 @@
-{ 
+{
   "app.customFeedback.confirmation.message": "Thank you for your feedback! The window will close shortly",
   "app.customFeedback.windowWillClose": "The window will close shortly",
   "app.customFeedback.feedbackTitle": "End-of-Session Feedback",
@@ -75,5 +75,17 @@
   "app.customFeedback.appsGallery.appUnusable": "I think it's difficult to use",
   "app.customFeedback.appsGallery.appPinThree": "I'd like to pin more than 3 features",
   "app.customFeedback.other": "Other:",
-  "app.customFeedback.describeProblem": "Describe it here."
+  "app.customFeedback.describeProblem": "Describe it here.",
+  "app.customFeedback.errors.max_participants_reason": "The maximum number of participants allowed for this session has been reached",
+  "app.customFeedback.errors.guest_deny": "Guest denied of joining the session.",
+  "app.customFeedback.errors.meeting_ended": "This session has ended",
+  "app.customFeedback.errors.validate_token_failed_eject_reason": "Authentication failed",
+  "app.customFeedback.errors.banned_user_rejoining_reason": "User has been banned",
+  "app.customFeedback.errors.duplicate_user_in_meeting_eject_reason": "Duplicate user trying to join session",
+  "app.customFeedback.errors.checksumError": "The request could not be authenticated. Please try again.",
+  "app.customFeedback.errors.invalidMeetingId": "Meeting not found.",
+  "app.customFeedback.errors.meetingForciblyEnded": "You cannot join a session that has already been forcibly ended",
+  "app.customFeedback.errors.invalidPassword": "The password you provided is incorrect.",
+  "app.customFeedback.errors.mismatchCreateTime": "The meeting information is outdated. Please try again.",
+  "app.customFeedback.errors.generic": "Could not join the meeting ({reason})."
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -75,5 +75,17 @@
   "app.customFeedback.appsGallery.appUnusable": "Me resulta difícil de usar",
   "app.customFeedback.appsGallery.appPinThree": "Me gustaría anclar más de 3 funcionalidades",
   "app.customFeedback.other": "Otro:",
-  "app.customFeedback.describeProblem": "Describe aquí"
+  "app.customFeedback.describeProblem": "Describe aquí",
+  "app.customFeedback.errors.max_participants_reason": "È stato raggiunto il numero massimo di partecipanti consentito per questa sessione",
+  "app.customFeedback.errors.guest_deny": "Accesso ospite alla sessione negato.",
+  "app.customFeedback.errors.meeting_ended": "Questa sessione è terminata",
+  "app.customFeedback.errors.validate_token_failed_eject_reason": "Autenticazione fallita",
+  "app.customFeedback.errors.banned_user_rejoining_reason": "L'utente è stato bannato",
+  "app.customFeedback.errors.duplicate_user_in_meeting_eject_reason": "Utente duplicato che tenta di unirsi alla sessione",
+  "app.customFeedback.errors.checksumError": "Impossibile autenticare la richiesta. Per favore, riprova.",
+  "app.customFeedback.errors.invalidMeetingId": "Riunione non trovata.",
+  "app.customFeedback.errors.meetingForciblyEnded": "Non puoi unirti a una sessione che è già stata terminata forzatamente",
+  "app.customFeedback.errors.invalidPassword": "La password fornita non è corretta.",
+  "app.customFeedback.errors.mismatchCreateTime": "Le informazioni sulla riunione non sono aggiornate. Per favore, riprova.",
+  "app.customFeedback.errors.generic": "Impossibile partecipare alla riunione ({reason})."
 }

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1,4 +1,4 @@
-{ 
+{
   "app.customFeedback.confirmation.message": "Grazie per il tuo feedback! La finestra si chiuderà a breve",
   "app.customFeedback.windowWillClose": "La finestra si chiuderà a breve",
   "app.customFeedback.feedbackTitle": "Feedback di fine sessione",
@@ -75,5 +75,17 @@
   "app.customFeedback.appsGallery.appUnusable": "Trovo difficile da usare",
   "app.customFeedback.appsGallery.appPinThree": "Vorrei ancorare più di 3 funzionalità",
   "app.customFeedback.other": "Altro:",
-  "app.customFeedback.describeProblem": "Descrivilo qui."
+  "app.customFeedback.describeProblem": "Descrivilo qui.",
+  "app.customFeedback.errors.max_participants_reason": "La riunione ha raggiunto il numero massimo di partecipanti.",
+  "app.customFeedback.errors.guest_deny": "Il tuo accesso come ospite a questa riunione è stato negato.",
+  "app.customFeedback.errors.meeting_ended": "La riunione è terminata.",
+  "app.customFeedback.errors.validate_token_failed_eject_reason": "Autenticazione fallita. Per favore, riprova.",
+  "app.customFeedback.errors.banned_user_rejoining_reason": "Sei stato bandito da questa riunione.",
+  "app.customFeedback.errors.duplicate_user_in_meeting_eject_reason": "Un utente con lo stesso nome è già nella riunione.",
+  "app.customFeedback.errors.checksumError": "Impossibile autenticare la richiesta. Per favore, riprova.",
+  "app.customFeedback.errors.invalidMeetingId": "La riunione a cui stai cercando di partecipare non esiste.",
+  "app.customFeedback.errors.meetingForciblyEnded": "Non puoi rientrare in una riunione che è stata terminata forzatamente.",
+  "app.customFeedback.errors.invalidPassword": "La password fornita non è corretta.",
+  "app.customFeedback.errors.mismatchCreateTime": "Le informazioni sulla riunione non sono aggiornate. Per favore, riprova.",
+  "app.customFeedback.errors.generic": "Impossibile partecipare alla riunione ({reason})."
 }

--- a/frontend/src/locales/pt_BR.json
+++ b/frontend/src/locales/pt_BR.json
@@ -75,5 +75,17 @@
   "app.customFeedback.appsGallery.appUnusable": "Acho difícil de usar",
   "app.customFeedback.appsGallery.appPinThree": "Vorrei fissare più di 3 funzionalità",
   "app.customFeedback.other": "Outro:",
-  "app.customFeedback.describeProblem": "Descreva aqui."
+  "app.customFeedback.describeProblem": "Descreva aqui.",
+  "app.customFeedback.errors.max_participants_reason": "O número máximo de participantes permitido para esta sessão foi atingido",
+  "app.customFeedback.errors.guest_deny": "Acesso de convidado à sessão foi negado.",
+  "app.customFeedback.errors.meeting_ended": "Esta sessão terminou",
+  "app.customFeedback.errors.validate_token_failed_eject_reason": "Falha na autenticação",
+  "app.customFeedback.errors.banned_user_rejoining_reason": "O usuário foi banido",
+  "app.customFeedback.errors.duplicate_user_in_meeting_eject_reason": "Usuário duplicado tentando entrar na sessão",
+  "app.customFeedback.errors.checksumError": "Não foi possível autenticar sua solicitação. Por favor, tente novamente.",
+  "app.customFeedback.errors.invalidMeetingId": "Reunião não encontrada.",
+  "app.customFeedback.errors.meetingForciblyEnded": "Você não pode entrar em uma sessão que já foi encerrada à força",
+  "app.customFeedback.errors.invalidPassword": "A senha informada está incorreta.",
+  "app.customFeedback.errors.mismatchCreateTime": "As informações da reunião estão desatualizadas. Por favor, tente novamente.",
+  "app.customFeedback.errors.generic": "Não foi possível entrar na reunião ({reason})."
 }


### PR DESCRIPTION
Handles different error formats (`reason` and `errors` parameters) when a user fails to join a meeting.

This change introduces:
- A mapping (`reasonKeyMap`) to normalize inconsistent error keys from different API responses.
- Logic to parse both `reason` (string) and `errors` (JSON array) query parameters from the logout URL.
- New translations for a comprehensive list errors in English, Portuguese, Spanish, and Italian to provide user-friendly feedback.

### More
Some images of errors examples:
#### Room with "Deny all" guest policy - join as guest
<img width="737" height="255" alt="Screenshot from 2025-09-23 12-30-11" src="https://github.com/user-attachments/assets/e3560f20-0cfa-428e-8dbd-dabd3b5d64d0" />

#### Room with maxParticipants=2 - join with a 3rd user
<img width="737" height="255" alt="Screenshot from 2025-09-23 12-30-47" src="https://github.com/user-attachments/assets/036a036b-44bf-4fff-8eff-9742dd6fd5aa" />

