### PR TITLE
feat: add early skip for specific reason/error codes

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -5,6 +5,21 @@ const activeKeys = [];
 
 const apiPath = process.env.API_PATH || '/bigbluebutton/api/';
 const REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS = process.env.REDIS_HASH_KEYS_EXPIRATION_IN_SECONDS || 24 * 3600;
+export const REASON_CODE_NOT_ELEGIBLE_FOR_FEEDBACK = [
+  'max_participants_reason',
+  'system_requested_eject_reason',
+  'user_requested_eject_reason',
+  'banned_user_rejoining_reason',
+];
+export const ERROR_CODE_NOT_ELEGIBLE_FOR_FEEDBACK = [
+  'checkssumError',
+  'invalidMeetingId',
+  'meetingForciblyEnded',
+  'invalidPassword',
+  'mismatchCreateTime',
+  'maxParticipantsReached',
+  'guestDeniedAccess',
+];
 
 /**
  * queryFromUrl - Returns the query string from a URL string while preserving

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -12,7 +12,7 @@ export const REASON_CODE_NOT_ELEGIBLE_FOR_FEEDBACK = [
   'banned_user_rejoining_reason',
 ];
 export const ERROR_CODE_NOT_ELEGIBLE_FOR_FEEDBACK = [
-  'checkssumError',
+  'checksumError',
   'invalidMeetingId',
   'meetingForciblyEnded',
   'invalidPassword',


### PR DESCRIPTION
There are scenarios where users should not be allowed to submit feedback even when they still have a valid session. This change introduces logic to automatically skip the feedback flow when specific reason/error codes are received.

NOTE: This change depends on a core update that adds the reason code as a query parameter to the logout URL: https://github.com/bigbluebutton/bigbluebutton/pull/24542