### PR TITLE
feat: serve static assets via nginx instead of express

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,16 @@ RUN npm install
 # Copie todos os arquivos do projeto para o diretório de trabalho
 COPY backend/ .
 
-# Copie os arquivos buildados do frontend para o backend
-COPY --from=build-frontend /usr/src/app/frontend/build ./public
+# Copie os arquivos buildados do frontend para um diretório temporário
+COPY --from=build-frontend /usr/src/app/frontend/build /app/built-assets
 
 # Exponha a porta em que a aplicação será executada
 EXPOSE 3009
 
-# Comando para iniciar a aplicação
-CMD ["npm", "start"]
+# Copie o entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Use o entrypoint script para copiar os assets e iniciar o servidor
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -53,19 +53,41 @@ Changes the docker-compose.yml to fit your use case. **Note:** Ensure there are 
 
 ## Deploying to Production
 
-After spinning up the back-end server you'll need to drop this nginx file on your server:
+### 1. Build and start the container
 
+```bash
+docker compose up -d
 ```
-/usr/share/bigbluebutton/feedback.nginx
+
+On first start, the container copies the built static assets into the host directory `/usr/share/bigbluebutton/feedback/`. This directory is bind-mounted via `docker-compose.yml` and will be served directly by nginx.
+
+### 2. Configure nginx
+
+Copy the `feedback.nginx` file from this repository to `/etc/bigbluebutton/nginx/feedback.nginx` on the BBB host, then reload nginx:
+
+```bash
+sudo cp feedback.nginx /etc/bigbluebutton/nginx/feedback.nginx
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+The nginx configuration serves static assets (HTML, JS, CSS) directly from disk and proxies only API endpoints to the back-end:
+
+```nginx
+location = /feedback/check   { proxy_pass http://localhost:3009; }
+location = /feedback/submit  { proxy_pass http://localhost:3009; }
+location = /feedback/webhook { proxy_pass http://localhost:3009; }
 
 location /feedback {
-        proxy_pass http://localhost:3009/feedback;
+  root /usr/share/bigbluebutton;
+  try_files $uri /feedback/index.html;
 }
 ```
 
-Configure `bbb-web` to redirect logged out users to the custom feedback application after they leave the meeting:
+### 3. Configure bbb-web
 
-The correct value should be https://YOUR_BBB_HOST/feedback?userId=%%USERID%%&meetingId=%%MEETINGID%%
+Configure `bbb-web` to redirect logged-out users to the feedback application after they leave the meeting.
+
+The redirect URL should be `https://YOUR_BBB_HOST/feedback?userId=%%USERID%%&meetingId=%%MEETINGID%%`
 
 * Edit `logoutURL` in `/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties`
 * Or create your meeting with `logoutURL`

--- a/backend/server.js
+++ b/backend/server.js
@@ -108,7 +108,7 @@ async function destroyHook() {
   }
 }
 
-app.use('/feedback', async (req, res, next) => {
+app.get('/feedback/check', async (req, res) => {
   const {
     userId,
     meetingId,
@@ -127,7 +127,7 @@ app.use('/feedback', async (req, res, next) => {
     logger.error({ err: e, rawErrors }, 'Error parsing errors param');
   }
 
-  logger.debug({ query: req.query, parsedErrors: errors }, 'Middleware: Processing feedback request');
+  logger.debug({ query: req.query, parsedErrors: errors }, 'Check: Processing feedback request');
 
   // Reason/Error codes that justify skipping feedback even when user has a valid session
   const hasSkipReason = REASON_CODE_NOT_ELEGIBLE_FOR_FEEDBACK.includes(reasonCode);
@@ -137,9 +137,8 @@ app.use('/feedback', async (req, res, next) => {
     const params = new URLSearchParams({ skipped: 'true' });
     const message = reason || errors[0]?.message;
     if (message) params.set('reason', message);
-
     logger.info(`Forced feedback skip: ${hasSkipReason ? `reason code: ${reasonCode}` : `error code: ${errors[0].key}`}`);
-    return res.redirect(`/feedback?${params.toString()}`);
+    return res.json({ redirect: `/feedback?${params.toString()}` });
   }
 
   if (userId && meetingId && !skipped) {
@@ -167,20 +166,18 @@ app.use('/feedback', async (req, res, next) => {
       }
 
       logger.info(`Feedback skipped for user ${userId}, redirecting to confirmation screen.`);
-      return res.redirect(`/feedback?${params.toString()}`);
+      return res.json({ redirect: `/feedback?${params.toString()}` });
     }
   }
 
   const userLocale = usersLocales[userId];
   if (userLocale && !req.query.locale) {
-    req.query.locale = userLocale;
-    const queryString = new URLSearchParams(req.query).toString();
-    const newUrl = `${req.baseUrl}${req.path}?${queryString}`;
-    logger.debug(`Redirecting to ${newUrl}`);
-    return res.redirect(newUrl);
+    logger.debug(`Returning locale override for user ${userId}: ${userLocale}`);
+    return res.json({ proceed: true, locale: userLocale });
   }
-  next();
-}, express.static(path.resolve('./public')));
+
+  return res.json({ proceed: true });
+});
 
 
 app.post('/feedback/webhook', async (req, res) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,5 @@ services:
       - PORT=3009
       - REDIS_HOST=localhost
       - REGISTER_HOOKS=false
+    volumes:
+      - /usr/share/bigbluebutton/feedback:/app/public-assets

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Copia os assets buildados para o volume montado
+if [ -d /app/built-assets ]; then
+  cp -r /app/built-assets/* /app/public-assets/
+fi
+
+exec "$@"

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -5,18 +5,39 @@ import pt_BR from './locales/pt_BR.json';
 import en from './locales/en.json';
 import es from './locales/es.json';
 
-const browserLocale = navigator.language;
-const params = new URLSearchParams(window.location.search);
-const urlLocale = params.get('locale');
-const userLocale = urlLocale || browserLocale;
 
-const messages = userLocale.startsWith('pt') ? pt_BR :
-                 userLocale.startsWith('es') ? es :
-                 en;
+async function startApp() {
+  const browserLocale = navigator.language;
+  const params = new URLSearchParams(window.location.search);
+  const urlLocale = params.get('locale');
+  let userLocale = urlLocale || browserLocale;
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <IntlProvider locale={userLocale} messages={messages}>
-    <App />
-  </IntlProvider>
-);
+  try {
+    const checkRes = await fetch(`/feedback/check?${window.location.search.replace(/^\?/, '')}`);
+    if (checkRes.ok) {
+      const check = await checkRes.json();
+      if (check.redirect) {
+        window.location.replace(check.redirect);
+        return;
+      }
+      if (check.locale) {
+        userLocale = check.locale;
+      }
+    }
+  } catch (e) {
+    console.error('Error checking feedback:', e);
+  }
+
+  const messages = userLocale.startsWith('pt') ? pt_BR :
+                   userLocale.startsWith('es') ? es :
+                   en;
+
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(
+    <IntlProvider locale={userLocale} messages={messages}>
+      <App />
+    </IntlProvider>
+  );
+}
+
+startApp();


### PR DESCRIPTION
Static assets are now served directly by nginx instead of being proxied through the Node.js backend. The backend retains only API responsibilities.

#### Dockerfile
Built frontend assets are copied to `/app/built-assets/` instead of `backend/public/`. A `docker-entrypoint.sh` is set as the image entrypoint.

#### docker-entrypoint.sh
On container start, copies `/app/built-assets/` into the bind-mounted host directory, then starts the Node.js server.

#### docker-compose.yml
Adds a bind mount: `/usr/share/bigbluebutton/feedback` → `/app/public-assets`. nginx on the BBB host reads assets from this path.

#### feedback.nginx
Replaces the old `proxy_pass`-everything config. Uses exact-match `location` blocks to proxy `/feedback/check`, `/feedback/submit` and `/feedback/webhook` to the backend; a prefix `location /feedback` with `try_files` serves static assets directly.

#### backend/server.js
Removes `express.static`. Adds `GET /feedback/check` endpoint that runs the eligibility and locale-override logic (previously in Express middleware) and returns JSON `{ redirect }` or `{ proceed, locale }`.

#### frontend/src/index.jsx
Calls `/feedback/check` before rendering. Redirects if the backend signals ineligibility; applies locale override if provided; falls back to browser locale on network error.

## Deploy steps

1. `docker compose up -d`
2. `sudo cp feedback.nginx /etc/bigbluebutton/nginx/feedback.nginx`
3. `sudo nginx -t && sudo systemctl reload nginx`